### PR TITLE
Secure players endpoint with JWT auth

### DIFF
--- a/src/main/java/com/tjardas/iisapi/config/SecurityConfig.java
+++ b/src/main/java/com/tjardas/iisapi/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -40,8 +39,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/players").authenticated()
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/players/**").authenticated()
+                        .anyRequest().authenticated()
                 ).addFilterBefore(new JwtAuthenticationFilter(jwtUtils, userDetailsService), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }


### PR DESCRIPTION
## Summary
- allow unauthenticated access only to `/api/auth/**`
- enforce authentication on `/api/players/**`

## Testing
- `./mvnw -q clean test` *(fails: Failed to fetch Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68a86c949484832a8ab9378fdc2bc016