### PR TITLE
Integrate PocketBase for player storage and replace JPA repository with NbaApiService

### DIFF
--- a/src/main/java/com/tjardas/iisapi/controller/PlayerController.java
+++ b/src/main/java/com/tjardas/iisapi/controller/PlayerController.java
@@ -1,7 +1,6 @@
 package com.tjardas.iisapi.controller;
 
 import com.tjardas.iisapi.model.PlayerEntity;
-import com.tjardas.iisapi.repository.PlayerRepository;
 import com.tjardas.iisapi.xml.Players;
 import com.tjardas.iisapi.service.NbaApiService;
 import com.tjardas.iisapi.service.XmlValidationService;
@@ -31,7 +30,6 @@ public class PlayerController {
 
     private final NbaApiService nbaApiService;
     private final XmlValidationService xmlValidationService;
-    private final PlayerRepository playerRepository;
 
     @GetMapping(produces = MediaType.APPLICATION_XML_VALUE, path = "/players")
     public String getPlayersAsXml(
@@ -75,9 +73,11 @@ public class PlayerController {
             }
         }
 
-        playerRepository.saveAll(playerEntities);
-        playerRepository.findAll().forEach(playerEntity -> log.info(playerEntity.toString()));
+        playerEntities.forEach(player -> {
+            PlayerEntity created = nbaApiService.createPlayer(player);
+            log.info("Saved PlayerEntity to PocketBase: {}", created);
+        });
 
-        return "XML successfully validated and saved!";
+        return "XML successfully validated and saved to PocketBase players collection!";
     }
 }

--- a/src/main/java/com/tjardas/iisapi/controller/PlayerCrudController.java
+++ b/src/main/java/com/tjardas/iisapi/controller/PlayerCrudController.java
@@ -1,7 +1,7 @@
 package com.tjardas.iisapi.controller;
 
 import com.tjardas.iisapi.model.PlayerEntity;
-import com.tjardas.iisapi.repository.PlayerRepository;
+import com.tjardas.iisapi.service.NbaApiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,41 +13,31 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlayerCrudController {
 
-    private final PlayerRepository playerRepository;
+    private final NbaApiService nbaApiService;
 
     @GetMapping
     public List<PlayerEntity> getAll() {
-        return playerRepository.findAll();
+        return nbaApiService.getAllPlayers();
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<PlayerEntity> getById(@PathVariable Long id) {
-        return playerRepository.findById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    @GetMapping("/{recordId}")
+    public ResponseEntity<PlayerEntity> getById(@PathVariable String recordId) {
+        return ResponseEntity.ok(nbaApiService.getPlayerById(recordId));
     }
 
     @PostMapping
     public PlayerEntity create(@RequestBody PlayerEntity player) {
-        return playerRepository.save(player);
+        return nbaApiService.createPlayer(player);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<PlayerEntity> update(@PathVariable Long id, @RequestBody PlayerEntity player) {
-        return playerRepository.findById(id)
-                .map(existing -> {
-                    player.setId(existing.getId());
-                    return ResponseEntity.ok(playerRepository.save(player));
-                })
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    @PatchMapping("/{recordId}")
+    public ResponseEntity<PlayerEntity> update(@PathVariable String recordId, @RequestBody PlayerEntity player) {
+        return ResponseEntity.ok(nbaApiService.updatePlayer(recordId, player));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        if (playerRepository.existsById(id)) {
-            playerRepository.deleteById(id);
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.notFound().build();
+    @DeleteMapping("/{recordId}")
+    public ResponseEntity<Void> delete(@PathVariable String recordId) {
+        nbaApiService.deletePlayer(recordId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/tjardas/iisapi/model/PlayerEntity.java
+++ b/src/main/java/com/tjardas/iisapi/model/PlayerEntity.java
@@ -1,5 +1,7 @@
 package com.tjardas.iisapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +16,12 @@ public class PlayerEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
     private Long id;
+
+    @Transient
+    @JsonProperty("id")
+    private String recordId;
 
     @Column(name = "player_name")
     private String name;
@@ -32,6 +39,7 @@ public class PlayerEntity {
     public String toString() {
         return "PlayerEntity{" +
                 "id=" + id +
+                ", recordId='" + recordId + '\'' +
                 ", name='" + name + '\'' +
                 ", team='" + team + '\'' +
                 ", season=" + season +

--- a/src/main/java/com/tjardas/iisapi/service/NbaApiService.java
+++ b/src/main/java/com/tjardas/iisapi/service/NbaApiService.java
@@ -1,75 +1,145 @@
 package com.tjardas.iisapi.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tjardas.iisapi.model.PlayerEntity;
 import com.tjardas.iisapi.xml.Players;
-import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 @Slf4j
 public class NbaApiService {
-    private static final String API_URL = "https://api-nba-v1.p.rapidapi.com/players/statistics?game=8133";
-    private static final String API_HOST = "api-nba-v1.p.rapidapi.com";
-    private static final String DEFAULT_API_KEY = "1878146bcdmsh2932967a89b2b3ap1e33a9jsn34f5e618dc13";
 
-    private final List<Players.Player> records = new ArrayList<>();
+    private static final String PLAYERS_COLLECTION = "players";
+
+    @Value("${pocketbase.instance}")
+    private String pocketBaseInstance;
+
+    @Value("${pocketbase.auth-token:}")
+    private String pocketBaseAuthToken;
+
     private final RestTemplate restTemplate = new RestTemplate();
-    private final ObjectMapper mapper = new ObjectMapper();
-
-    @PostConstruct
-    public void loadApiData() {
-        String apiKey = System.getenv("RAPIDAPI_KEY");
-        if (apiKey == null || apiKey.isBlank()) {
-            apiKey = DEFAULT_API_KEY;
-        }
-
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-RapidAPI-Key", apiKey);
-            headers.set("X-RapidAPI-Host", API_HOST);
-            headers.setContentType(MediaType.APPLICATION_JSON);
-
-            HttpEntity<String> requestEntity = new HttpEntity<>(headers);
-            ResponseEntity<String> response = restTemplate.exchange(
-                    API_URL, HttpMethod.GET, requestEntity, String.class);
-
-            if (response.getBody() != null) {
-                JsonNode root = mapper.readTree(response.getBody());
-                JsonNode dataArray = root.path("response");
-                if (dataArray.isArray()) {
-                    for (JsonNode node : dataArray) {
-                        Players.Player p = new Players.Player();
-                        String first = node.path("player").path("firstname").asText("");
-                        String last = node.path("player").path("lastname").asText("");
-                        p.setName((first + " " + last).trim());
-                        p.setTeam(node.path("team").path("name").asText(""));
-                        p.setSeason(node.path("game").path("season").asInt(0));
-                        p.setPoints((float) node.path("points").asDouble(0));
-                        records.add(p);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching data from API", e);
-        }
-    }
 
     public Players getFilteredPlayers(String name, String team, Integer season) {
-        List<Players.Player> filtered = records.stream()
-                .filter(r -> name == null || r.getName().equalsIgnoreCase(name))
-                .filter(r -> team == null || r.getTeam().equalsIgnoreCase(team))
-                .filter(r -> season == null || r.getSeason() == season)
-                .toList();
+        String endpoint = String.format("%s/api/collections/%s/records", pocketBaseInstance, PLAYERS_COLLECTION);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildHeaders());
+        ResponseEntity<JsonNode> response = restTemplate.exchange(endpoint, HttpMethod.GET, requestEntity, JsonNode.class);
+
+        List<Players.Player> filtered = new ArrayList<>();
+        JsonNode items = response.getBody() == null ? null : response.getBody().path("items");
+
+        if (items != null && items.isArray()) {
+            for (JsonNode node : items) {
+                Players.Player player = toXmlPlayer(node);
+                if ((name == null || player.getName().equalsIgnoreCase(name))
+                        && (team == null || player.getTeam().equalsIgnoreCase(team))
+                        && (season == null || player.getSeason() == season)) {
+                    filtered.add(player);
+                }
+            }
+        }
 
         Players players = new Players();
         players.setPlayers(filtered);
         return players;
+    }
+
+    public List<PlayerEntity> getAllPlayers() {
+        String endpoint = String.format("%s/api/collections/%s/records", pocketBaseInstance, PLAYERS_COLLECTION);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildHeaders());
+        ResponseEntity<JsonNode> response = restTemplate.exchange(endpoint, HttpMethod.GET, requestEntity, JsonNode.class);
+
+        List<PlayerEntity> players = new ArrayList<>();
+        JsonNode items = response.getBody() == null ? null : response.getBody().path("items");
+
+        if (items != null && items.isArray()) {
+            for (JsonNode item : items) {
+                players.add(toEntity(item));
+            }
+        }
+
+        return players;
+    }
+
+    public PlayerEntity getPlayerById(String recordId) {
+        String endpoint = String.format("%s/api/collections/%s/records/%s", pocketBaseInstance, PLAYERS_COLLECTION, recordId);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildHeaders());
+        ResponseEntity<JsonNode> response = restTemplate.exchange(endpoint, HttpMethod.GET, requestEntity, JsonNode.class);
+        return toEntity(response.getBody());
+    }
+
+    public PlayerEntity createPlayer(PlayerEntity player) {
+        String endpoint = String.format("%s/api/collections/%s/records", pocketBaseInstance, PLAYERS_COLLECTION);
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(toPocketBasePayload(player), buildHeaders());
+        ResponseEntity<JsonNode> response = restTemplate.exchange(endpoint, HttpMethod.POST, requestEntity, JsonNode.class);
+        return toEntity(response.getBody());
+    }
+
+    public PlayerEntity updatePlayer(String recordId, PlayerEntity player) {
+        String endpoint = String.format("%s/api/collections/%s/records/%s", pocketBaseInstance, PLAYERS_COLLECTION, recordId);
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(toPocketBasePayload(player), buildHeaders());
+        ResponseEntity<JsonNode> response = restTemplate.exchange(endpoint, HttpMethod.PATCH, requestEntity, JsonNode.class);
+        return toEntity(response.getBody());
+    }
+
+    public void deletePlayer(String recordId) {
+        String endpoint = String.format("%s/api/collections/%s/records/%s", pocketBaseInstance, PLAYERS_COLLECTION, recordId);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildHeaders());
+        restTemplate.exchange(endpoint, HttpMethod.DELETE, requestEntity, Void.class);
+    }
+
+    private HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (pocketBaseAuthToken != null && !pocketBaseAuthToken.isBlank()) {
+            headers.setBearerAuth(pocketBaseAuthToken);
+        }
+        return headers;
+    }
+
+    private Map<String, Object> toPocketBasePayload(PlayerEntity player) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("name", player.getName());
+        payload.put("team", player.getTeam());
+        payload.put("season", player.getSeason());
+        payload.put("points", player.getPoints());
+        return payload;
+    }
+
+    private Players.Player toXmlPlayer(JsonNode node) {
+        Players.Player player = new Players.Player();
+        player.setName(node.path("name").asText(""));
+        player.setTeam(node.path("team").asText(""));
+        player.setSeason(node.path("season").asInt(0));
+        player.setPoints((float) node.path("points").asDouble(0));
+        return player;
+    }
+
+    private PlayerEntity toEntity(JsonNode node) {
+        PlayerEntity player = new PlayerEntity();
+        if (node == null) {
+            return player;
+        }
+
+        String rawId = node.path("id").asText("");
+        if (!rawId.isBlank()) {
+            player.setRecordId(rawId);
+        }
+
+        player.setName(node.path("name").asText(""));
+        player.setTeam(node.path("team").asText(""));
+        player.setSeason(node.path("season").asInt(0));
+        player.setPoints((float) node.path("points").asDouble(0));
+        return player;
     }
 }

--- a/src/main/java/com/tjardas/iisapi/xml/Players.java
+++ b/src/main/java/com/tjardas/iisapi/xml/Players.java
@@ -19,7 +19,7 @@ public class Players {
         this.players = players;
     }
 
-    @XmlType(namespace = "http://example.com/players")
+    @XmlType(namespace = "http://example.com/players", propOrder = {"name", "team", "season", "points"})
     public static class Player {
         private String name;
         private String team;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,11 +5,6 @@ spring.datasource.password=password
 spring.datasource.hikari.maximum-pool-size=10
 spring.jpa.hibernate.ddl-auto=update
 
-
-
-
-# Hibernate Configurationpassword
-
 # H2 Console Configuration
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
@@ -17,3 +12,6 @@ spring.h2.console.path=/h2-console
 spring.application.name=iis-api
 logging.level.com.tjardas.iisapi=DEBUG
 
+# PocketBase configuration
+pocketbase.instance=http://localhost:8090
+pocketbase.auth-token=

--- a/src/main/resources/player-validation.xsd
+++ b/src/main/resources/player-validation.xsd
@@ -7,8 +7,8 @@
                         <xs:sequence>
                             <xs:element name="name" type="xs:string"/>
                             <xs:element name="team" type="xs:string"/>
-                            <xs:element name="points" type="xs:float"/>
                             <xs:element name="season" type="xs:int"/>
+                            <xs:element name="points" type="xs:float"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>


### PR DESCRIPTION
### Motivation
- Move player persistence from a local JPA `PlayerRepository` to a PocketBase-backed REST service to centralize storage. 
- Provide a single service layer to fetch, create, update and delete players via HTTP rather than direct DB access. 
- Ensure imported XML players are validated and saved into the PocketBase `players` collection.

### Description
- Rewrote `NbaApiService` to call PocketBase REST endpoints and implemented `getFilteredPlayers`, `getAllPlayers`, `getPlayerById`, `createPlayer`, `updatePlayer`, and `deletePlayer`, plus helpers for header building and payload/DTO mapping, and added `pocketbase.instance` and `pocketbase.auth-token` configuration properties. 
- Removed direct injection/usage of `PlayerRepository` from `PlayerController` and `PlayerCrudController` and updated both controllers to use `NbaApiService`, changed route parameter types to PocketBase record ids (`String`) and switched update to `PATCH`. 
- Modified `PlayerEntity` to hide the JPA `id` from JSON (`@JsonIgnore`) and add a transient `recordId` property exposed as JSON `id`, and updated `toString` accordingly. 
- Adjusted XML binding with `Players.Player` `@XmlType` `propOrder`, updated the XSD ordering of `season`/`points`, and added PocketBase defaults to `application.properties`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3a510518832aa907479de4898cc5)