### PR TITLE
Fix PATCH support for PocketBase player updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
             <version>4.5.13</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/src/main/java/com/tjardas/iisapi/service/NbaApiService.java
+++ b/src/main/java/com/tjardas/iisapi/service/NbaApiService.java
@@ -29,7 +29,7 @@ public class NbaApiService {
     @Value("${pocketbase.auth-token:}")
     private String pocketBaseAuthToken;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
 
     public Players getFilteredPlayers(String name, String team, Integer season) {
         String endpoint = String.format("%s/api/collections/%s/records", pocketBaseInstance, PLAYERS_COLLECTION);


### PR DESCRIPTION
### Motivation

- `RestTemplate` used the default JDK `HttpURLConnection`, which produced `java.net.ProtocolException: Invalid HTTP method: PATCH` when sending PATCH requests to PocketBase, causing player updates to fail.

### Description

- Configure `RestTemplate` in `NbaApiService` to use `HttpComponentsClientHttpRequestFactory` and add the `org.apache.httpcomponents.client5:httpclient5` dependency in `pom.xml` so PATCH requests are supported at runtime.

### Testing

- Ran `mvn -q -DskipTests compile` to validate the changes, but the compile step did not complete because Maven Central returned HTTP 403 while resolving the Spring Boot parent POM, so automated build verification could not finish in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f241820f24832aae3901b2684c6de3)