### PR TITLE
Replace XML-RPC weather transport with gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IIS App
 
-This project is a Spring Boot backend that exposes NBA statistics, validates XML with XSD, supports SOAP-based player search, and offers an XML-RPC weather service.
+This project is a Spring Boot backend that exposes NBA statistics, validates XML with XSD, supports SOAP-based player search, and offers a gRPC weather service.
 
 ## Backend
 
@@ -16,7 +16,7 @@ Run the backend with Maven:
 - **Upload XML** to `/validateAndSaveXml` and show validation result.
 - **CRUD** operations against `/api/players/**` using stored JWT token.
 - **SOAP search** against `http://localhost:8080/ws`.
-- **XML-RPC weather** queries against `http://localhost:9090/RPC2`.
+- **gRPC weather** service on `localhost:9090` using `WeatherGrpcService/GetTemperature`.
 
 ### Configuration
 Set the `RAPIDAPI_KEY` environment variable to configure the RapidAPI key for external services.

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <grpc.version>1.69.0</grpc.version>
+        <protobuf.version>3.25.5</protobuf.version>
     </properties>
     <dependencies>
         <dependency>
@@ -89,11 +91,6 @@
             <version>3.4.5</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
-            <artifactId>xmlrpc-server</artifactId>
-            <version>3.1.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
@@ -101,6 +98,21 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -133,6 +145,30 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/tjardas/iisapi/WeatherServer.java
+++ b/src/main/java/com/tjardas/iisapi/WeatherServer.java
@@ -1,28 +1,25 @@
 package com.tjardas.iisapi;
 
+import com.tjardas.iisapi.grpc.WeatherGrpcServiceImpl;
 import com.tjardas.iisapi.service.WeatherService;
-import org.apache.xmlrpc.server.PropertyHandlerMapping;
-import org.apache.xmlrpc.server.XmlRpcServer;
-import org.apache.xmlrpc.server.XmlRpcServerConfigImpl;
-import org.apache.xmlrpc.webserver.WebServer;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
 
 public class WeatherServer {
 
     public static void main(String[] args) {
+        final int port = 9090;
+
         try {
-            WebServer webServer = new WebServer(9090);
-            XmlRpcServer xmlRpcServer = webServer.getXmlRpcServer();
+            Server server = ServerBuilder.forPort(port)
+                    .addService(new WeatherGrpcServiceImpl(new WeatherService()))
+                    .build()
+                    .start();
 
-            PropertyHandlerMapping phm = new PropertyHandlerMapping();
-            phm.addHandler("WeatherService", WeatherService.class);
-            xmlRpcServer.setHandlerMapping(phm);
+            System.out.println("gRPC weather server started on port " + port + ".");
 
-            XmlRpcServerConfigImpl serverConfig = (XmlRpcServerConfigImpl) xmlRpcServer.getConfig();
-            serverConfig.setEnabledForExtensions(true);
-            serverConfig.setContentLengthOptional(false);
-
-            webServer.start();
-            System.out.println("XML-RPC server started successfully.");
+            Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown));
+            server.awaitTermination();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/tjardas/iisapi/grpc/WeatherGrpcClient.java
+++ b/src/main/java/com/tjardas/iisapi/grpc/WeatherGrpcClient.java
@@ -1,0 +1,37 @@
+package com.tjardas.iisapi.grpc;
+
+import hr.algebra.weather.grpc.TemperatureRequest;
+import hr.algebra.weather.grpc.TemperatureResponse;
+import hr.algebra.weather.grpc.WeatherGrpcServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class WeatherGrpcClient implements AutoCloseable {
+
+    private final ManagedChannel channel;
+    private final WeatherGrpcServiceGrpc.WeatherGrpcServiceBlockingStub blockingStub;
+
+    public WeatherGrpcClient(String host, int port) {
+        this.channel = ManagedChannelBuilder.forAddress(host, port)
+                .usePlaintext()
+                .build();
+        this.blockingStub = WeatherGrpcServiceGrpc.newBlockingStub(channel);
+    }
+
+    public List<String> getTemperature(String cityName) {
+        TemperatureRequest request = TemperatureRequest.newBuilder()
+                .setCityName(cityName)
+                .build();
+
+        TemperatureResponse response = blockingStub.getTemperature(request);
+        return response.getResultsList();
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/tjardas/iisapi/grpc/WeatherGrpcServiceImpl.java
+++ b/src/main/java/com/tjardas/iisapi/grpc/WeatherGrpcServiceImpl.java
@@ -1,0 +1,26 @@
+package com.tjardas.iisapi.grpc;
+
+import com.tjardas.iisapi.service.WeatherService;
+import hr.algebra.weather.grpc.TemperatureRequest;
+import hr.algebra.weather.grpc.TemperatureResponse;
+import hr.algebra.weather.grpc.WeatherGrpcServiceGrpc;
+import io.grpc.stub.StreamObserver;
+
+public class WeatherGrpcServiceImpl extends WeatherGrpcServiceGrpc.WeatherGrpcServiceImplBase {
+
+    private final WeatherService weatherService;
+
+    public WeatherGrpcServiceImpl(WeatherService weatherService) {
+        this.weatherService = weatherService;
+    }
+
+    @Override
+    public void getTemperature(TemperatureRequest request, StreamObserver<TemperatureResponse> responseObserver) {
+        TemperatureResponse response = TemperatureResponse.newBuilder()
+                .addAllResults(weatherService.getTemperature(request.getCityName()))
+                .build();
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/weather.proto
+++ b/src/main/proto/weather.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "hr.algebra.weather.grpc";
+option java_outer_classname = "WeatherProto";
+
+service WeatherGrpcService {
+  rpc GetTemperature (TemperatureRequest) returns (TemperatureResponse);
+}
+
+message TemperatureRequest {
+  string cityName = 1;
+}
+
+message TemperatureResponse {
+  repeated string results = 1;
+}


### PR DESCRIPTION
### Motivation
- Replace the Apache XML-RPC transport used for the DHMZ weather lookup with a real gRPC transport while preserving the existing XML fetch, DOM parsing, partial/case-insensitive matching, and multi-result behavior in `WeatherService.getTemperature(...)`.

### Description
- Added `src/main/proto/weather.proto` defining `WeatherGrpcService/GetTemperature`, `TemperatureRequest`, and `TemperatureResponse`.
- Implemented `WeatherGrpcServiceImpl` that extends the generated gRPC base and delegates to the existing `WeatherService.getTemperature(cityName)` to preserve business logic and result format.
- Replaced the XML-RPC bootstrap in `WeatherServer` with a gRPC server on port `9090`, added a blocking `WeatherGrpcClient` helper, and updated `README.md` to reflect gRPC usage.
- Updated `pom.xml` to add gRPC dependencies and `protobuf-maven-plugin` codegen configuration and removed the weather-specific `org.apache.xmlrpc:xmlrpc-server` dependency.

### Testing
- Ran `./mvnw test -DskipTests=false`, which failed because the Maven wrapper could not download the Maven distribution in this environment.
- Ran `mvn -q -DskipTests compile`, which failed during dependency resolution because the Spring Boot parent POM could not be fetched from Maven Central (HTTP 403) in this environment.
- Because Maven dependency resolution/code generation could not complete here, the generated gRPC Java classes were not produced locally and full build/test verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098f1efe14832abe9d198c6189a0bf)