### PR TITLE
Add GraphQL Player API and clearer JSON type validation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/tjardas/iisapi/config/SecurityConfig.java
+++ b/src/main/java/com/tjardas/iisapi/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/players/**").authenticated()
+                .requestMatchers("/graphql").authenticated()
                 .anyRequest().permitAll()
             )
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/tjardas/iisapi/controller/PlayerGraphQlController.java
+++ b/src/main/java/com/tjardas/iisapi/controller/PlayerGraphQlController.java
@@ -1,0 +1,56 @@
+package com.tjardas.iisapi.controller;
+
+import com.tjardas.iisapi.model.PlayerEntity;
+import com.tjardas.iisapi.service.NbaApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class PlayerGraphQlController {
+
+    private final NbaApiService nbaApiService;
+
+    @QueryMapping
+    public List<PlayerEntity> players() {
+        return nbaApiService.getAllPlayers();
+    }
+
+    @QueryMapping
+    public PlayerEntity playerById(@Argument String recordId) {
+        return nbaApiService.getPlayerById(recordId);
+    }
+
+    @MutationMapping
+    public PlayerEntity createPlayer(@Argument PlayerInput input) {
+        return nbaApiService.createPlayer(toEntity(input));
+    }
+
+    @MutationMapping
+    public PlayerEntity updatePlayer(@Argument String recordId, @Argument PlayerInput input) {
+        return nbaApiService.updatePlayer(recordId, toEntity(input));
+    }
+
+    @MutationMapping
+    public Boolean deletePlayer(@Argument String recordId) {
+        nbaApiService.deletePlayer(recordId);
+        return true;
+    }
+
+    private PlayerEntity toEntity(PlayerInput input) {
+        return PlayerEntity.builder()
+                .name(input.name())
+                .team(input.team())
+                .season(input.season())
+                .points(input.points())
+                .build();
+    }
+
+    public record PlayerInput(String name, String team, Integer season, Float points) {
+    }
+}

--- a/src/main/java/com/tjardas/iisapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tjardas/iisapi/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.tjardas.iisapi.exception;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.tjardas.iisapi.dto.ErrorResponse;
 import jakarta.xml.bind.JAXBException;
 import org.springframework.http.HttpStatus;
@@ -62,9 +64,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException ex) {
+        Throwable rootCause = ex.getMostSpecificCause();
+        if (rootCause instanceof InvalidFormatException invalidFormatException) {
+            return ResponseEntity.badRequest().body(ErrorResponse.builder()
+                    .message("Validation failed.")
+                    .errors(List.of(buildTypeErrorMessage(invalidFormatException)))
+                    .build());
+        }
+
         return ResponseEntity.badRequest().body(ErrorResponse.builder()
-                .message("Request payload is not readable.")
-                .detail(ex.getMostSpecificCause() != null ? ex.getMostSpecificCause().getMessage() : ex.getMessage())
+                .message("Validation failed.")
+                .errors(List.of("Request payload is not readable."))
                 .build());
     }
 
@@ -89,5 +99,19 @@ public class GlobalExceptionHandler {
 
     private String formatFieldError(FieldError fieldError) {
         return fieldError.getField() + ": " + fieldError.getDefaultMessage();
+    }
+
+    private String buildTypeErrorMessage(InvalidFormatException ex) {
+        String fieldName = ex.getPath().stream()
+                .map(JsonMappingException.Reference::getFieldName)
+                .filter(name -> name != null && !name.isBlank())
+                .findFirst()
+                .orElse("field");
+
+        return switch (fieldName) {
+            case "season" -> "season must be a valid whole number.";
+            case "points" -> "points must be a valid number.";
+            default -> fieldName + " has an invalid value type.";
+        };
     }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,25 @@
+type Player {
+  recordId: ID
+  name: String
+  team: String
+  season: Int
+  points: Float
+}
+
+input PlayerInput {
+  name: String!
+  team: String!
+  season: Int!
+  points: Float!
+}
+
+type Query {
+  players: [Player]
+  playerById(recordId: ID!): Player
+}
+
+type Mutation {
+  createPlayer(input: PlayerInput!): Player
+  updatePlayer(recordId: ID!, input: PlayerInput!): Player
+  deletePlayer(recordId: ID!): Boolean
+}


### PR DESCRIPTION
### Motivation
- Return clear, user-friendly validation responses when incoming JSON has wrong field types instead of failing with a low-level Jackson error. 
- Expose a small backend-only GraphQL API that reuses existing business logic rather than replacing REST. 
- Secure GraphQL with the existing JWT-based security so behavior matches protected REST endpoints. 

### Description
- Added the GraphQL dependency by adding `spring-boot-starter-graphql` to `pom.xml` and created a schema at `src/main/resources/graphql/schema.graphqls` that defines `Player`, `PlayerInput`, `Query`, and `Mutation` types. 
- Implemented `PlayerGraphQlController` which maps GraphQL queries and mutations (`players`, `playerById`, `createPlayer`, `updatePlayer`, `deletePlayer`) and delegates to the existing `NbaApiService` methods to avoid duplicating business logic. 
- Updated `SecurityConfig` to require authentication for the `/graphql` endpoint (keeps existing REST and auth behavior intact). 
- Improved `GlobalExceptionHandler` to handle Jackson `InvalidFormatException` (wrapped in `HttpMessageNotReadableException`) and return a consistent `ErrorResponse` shape with field-specific messages such as `"season must be a valid whole number."` and `"points must be a valid number."`, while preserving existing `MethodArgumentNotValidException` handling for Jakarta validation errors. 
- Changed/added files: `pom.xml`, `src/main/java/com/tjardas/iisapi/exception/GlobalExceptionHandler.java`, `src/main/java/com/tjardas/iisapi/config/SecurityConfig.java`, `src/main/java/com/tjardas/iisapi/controller/PlayerGraphQlController.java` (new), and `src/main/resources/graphql/schema.graphqls` (new). 

### Testing
- Attempted to run the test suite with `./mvnw test -q`, but the environment failed to download the Maven distribution (`wget` error), so automated tests were not executed. 
- No other automated test runs were completed in this environment; changes are limited and intended to be compile-safe and backwards-compatible with existing REST endpoints and validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a22ad6fa8832a9fa143c570ffd808)